### PR TITLE
v2.0.6

### DIFF
--- a/harbaughsim16/Conference.m
+++ b/harbaughsim16/Conference.m
@@ -303,7 +303,7 @@
                 Team *b = availTeams[selTeam];
                 
                 Game *gm;
-                if ([HBSharedUtils randomValue] > 0.5) {
+                if (offsetOOC % 2 == 0) {
                     gm = [Game newGameWithHome:a away:b name:[NSString stringWithFormat:@"%@ vs %@",[b.conference substringWithRange:NSMakeRange(0, MIN(3, b.conference.length))],[a.conference substringWithRange:NSMakeRange(0, MIN(3, a.conference.length))]]];
                 } else {
                     gm = [Game newGameWithHome:b away:a name:[NSString stringWithFormat:@"%@ vs %@",[a.conference substringWithRange:NSMakeRange(0, MIN(3, a.conference.length))],[b.conference substringWithRange:NSMakeRange(0, MIN(3, b.conference.length))]]];
@@ -346,7 +346,7 @@
             }
             
             Game *gm;
-            if ([HBSharedUtils randomValue] > 0.5) {
+            if (r % 2 == 0) {
                 gm = [Game
                       newGameWithHome:a away:b name:@"In Conf"];
             } else {

--- a/harbaughsim16/HBSharedUtils.m
+++ b/harbaughsim16/HBSharedUtils.m
@@ -518,10 +518,10 @@ static UIColor *styleColor = nil;
                     [viewController.navigationItem.leftBarButtonItem setEnabled:YES];
                     [teamHeaderView.playButton setTitle:@" Play Week" forState:UIControlStateNormal];
                 } else if (simLeague.currentWeek == 12) {
-                    NSString *heisman = [simLeague getHeismanCeremonyStr];
-                    NSLog(@"HEISMAN: %@", heisman); //can't do anything with this result, just want to run it tbh
                     [teamHeaderView.playButton setTitle:@" Play Conf Championships" forState:UIControlStateNormal];
                 } else if (simLeague.currentWeek == 13) {
+                    NSString *heisman = [simLeague getHeismanCeremonyStr];
+                    NSLog(@"HEISMAN: %@", heisman); //can't do anything with this result, just want to run it tbh
                     [teamHeaderView.playButton setTitle:@" Play Bowl Games" forState:UIControlStateNormal];
                 } else if (simLeague.currentWeek == 14) {
                     [teamHeaderView.playButton setTitle:@" Play National Championship" forState:UIControlStateNormal];

--- a/harbaughsim16/HBSharedUtils.m
+++ b/harbaughsim16/HBSharedUtils.m
@@ -342,10 +342,26 @@ static UIColor *styleColor = nil;
     [alertController addAction:[UIAlertAction actionWithTitle:@"View Season Summary" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu Season Summary", (long)[[HBSharedUtils currentLeague] getCurrentYear]] message:[[HBSharedUtils currentLeague] seasonSummaryStr] preferredStyle:UIAlertControllerStyleAlert];
-            [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
+            [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
             [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
         });
     }]];
+    
+    [alertController addAction:[UIAlertAction actionWithTitle:@"View POTY Results" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            NSString *heismanString = [[HBSharedUtils currentLeague] getHeismanCeremonyStr];
+            NSArray *heismanParts = [heismanString componentsSeparatedByString:@"?"];
+            NSMutableString *composeHeis = [NSMutableString string];
+            for (int i = 1; i < heismanParts.count; i++) {
+                [composeHeis appendString:heismanParts[i]];
+            }
+            NSLog(@"HEISMAN: %@", composeHeis);
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu's Player of the Year", (long)([[HBSharedUtils currentLeague] getCurrentYear])] message:composeHeis preferredStyle:UIAlertControllerStyleAlert];
+            [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
+            [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
+        });
+    }]];
+    
     [alertController addAction:[UIAlertAction actionWithTitle:@"View Players Leaving" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
         [viewController.navigationController pushViewController:[[GraduatingPlayersViewController alloc] init] animated:YES];
     }]];
@@ -375,7 +391,7 @@ static UIColor *styleColor = nil;
             if (simLeague.currentWeek == 15) {
                 // Show NCG summary
                 UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu Season Summary", (long)([HBSharedUtils currentLeague].baseYear + simLeague.userTeam.teamHistoryDictionary.count)] message:[simLeague seasonSummaryStr] preferredStyle:UIAlertControllerStyleAlert];
-                [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
+                [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
                 [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
             } else if (simLeague.userTeam.gameWLSchedule.count > numGamesPlayed) {
                 // Played a game, show summary - show notification
@@ -469,7 +485,7 @@ static UIColor *styleColor = nil;
                 }
                 NSLog(@"HEISMAN: %@", composeHeis);
                 UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu's Player of the Year", (long)([HBSharedUtils currentLeague].baseYear + simLeague.userTeam.teamHistoryDictionary.count)] message:composeHeis preferredStyle:UIAlertControllerStyleAlert];
-                [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
+                [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
                 [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
                 [teamHeaderView.playButton setTitle:@" Play Bowl Games" forState:UIControlStateNormal];
             } else if (simLeague.currentWeek == 14) {
@@ -502,7 +518,7 @@ static UIColor *styleColor = nil;
             [[HBSharedUtils currentLeague] save];
 
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu Season Summary", (long)([HBSharedUtils currentLeague].baseYear + simLeague.userTeam.teamHistoryDictionary.count)] message:[simLeague seasonSummaryStr] preferredStyle:UIAlertControllerStyleAlert];
-            [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
+            [alertController addAction:[UIAlertAction actionWithTitle:@"Dismiss" style:UIAlertActionStyleCancel handler:nil]];
             [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
         } else {
             float simTime = 0.5;

--- a/harbaughsim16/HBSharedUtils.m
+++ b/harbaughsim16/HBSharedUtils.m
@@ -117,41 +117,41 @@ static UIColor *styleColor = nil;
     if (weekNotifs) {
         if (title == nil) {
             if ([tintColor isEqual:[HBSharedUtils styleColor]]) {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-success" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-success" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils successColor]]) {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"win" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"win" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils champColor]]) {
-                 [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"champs" duration:0.75 callback:nil];
+                 [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"champs" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils errorColor]]) {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-error" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-error" duration:1.00 callback:nil];
             } else {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"loss" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"loss" duration:1.00 callback:nil];
             }
         } else {
             if ([tintColor isEqual:[HBSharedUtils styleColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-success" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-success" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils successColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"win" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"win" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils champColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"champs" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"champs" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils errorColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-error" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-error" duration:1.00 callback:nil];
             } else {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"loss" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"loss" duration:1.00 callback:nil];
             }
         }
     } else { // weekNotifications disabled
         if (title == nil) {
             if ([tintColor isEqual:[HBSharedUtils styleColor]]) {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-success" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-success" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils errorColor]]) {
-                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-error" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:message subtitle:nil type:RMessageTypeCustom customTypeName:@"alternate-error" duration:1.00 callback:nil];
             }
         } else {
             if ([tintColor isEqual:[HBSharedUtils styleColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-success" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-success" duration:1.00 callback:nil];
             } else if ([tintColor isEqual:[HBSharedUtils errorColor]]) {
-                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-error" duration:0.75 callback:nil];
+                [RMessage showNotificationInViewController:viewController title:title subtitle:message type:RMessageTypeCustom customTypeName:@"alternate-error" duration:1.00 callback:nil];
             }
         }
     }
@@ -467,11 +467,10 @@ static UIColor *styleColor = nil;
                 for (int i = 1; i < heismanParts.count; i++) {
                     [composeHeis appendString:heismanParts[i]];
                 }
-
+                NSLog(@"HEISMAN: %@", composeHeis);
                 UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[NSString stringWithFormat:@"%lu's Player of the Year", (long)([HBSharedUtils currentLeague].baseYear + simLeague.userTeam.teamHistoryDictionary.count)] message:composeHeis preferredStyle:UIAlertControllerStyleAlert];
                 [alertController addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleCancel handler:nil]];
                 [viewController.tabBarController presentViewController:alertController animated:YES completion:nil];
-
                 [teamHeaderView.playButton setTitle:@" Play Bowl Games" forState:UIControlStateNormal];
             } else if (simLeague.currentWeek == 14) {
                 [teamHeaderView.playButton setTitle:@" Play National Championship" forState:UIControlStateNormal];

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>5</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/Info.plist
+++ b/harbaughsim16/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/harbaughsim16/League.m
+++ b/harbaughsim16/League.m
@@ -1471,86 +1471,91 @@
 }
 
 -(NSString*)getHeismanCeremonyStr {
-    BOOL putNewsStory = false;
-
-    heismanCandidates = [[self calculateHeismanCandidates] mutableCopy];
-    heisman = heismanCandidates[0];
-    heismanDecided = true;
-    putNewsStory = true;
-
-    NSString* heismanTop5 = @"\n";
-    NSMutableString* heismanStats = [NSMutableString string];
-    NSString* heismanWinnerStr = @"";
-    heismanFinalists = [NSMutableArray array];
-    //full results string
-    int i = 0;
-    int place = 1;
-    while (heismanFinalists.count < 5 && i < heismanCandidates.count) {
-        Player *p = heismanCandidates[i];
-        heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@"%d. %@ (%ld-%ld) - ",place,p.team.abbreviation,(long)p.team.wins,(long)p.team.losses]];
-        if ([p isKindOfClass:[PlayerQB class]]) {
-            PlayerQB *pqb = (PlayerQB*)p;
-            heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" QB %@: %ld votes\n\t(%ld TDs, %ld Int, %ld Yds)\n",[pqb getInitialName],(long)[pqb getHeismanScore],(long)pqb.statsTD,(long)pqb.statsInt,(long)pqb.statsPassYards]];
-        } else if ([p isKindOfClass:[PlayerRB class]]) {
-            PlayerRB *prb = (PlayerRB*)p;
-            heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" RB %@: %ld votes\n\t(%ld TDs, %ld Fum, %ld Yds)\n",[prb getInitialName],(long)[prb getHeismanScore],(long)prb.statsTD,(long)prb.statsFumbles,(long)prb.statsRushYards]];
-        } else if ([p isKindOfClass:[PlayerWR class]]) {
-            PlayerWR *pwr = (PlayerWR*)p;
-            heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" WR %@: %ld votes\n\t(%ld TDs, %ld Fum, %ld Yds)\n",[pwr getInitialName],(long)[pwr getHeismanScore],(long)pwr.statsTD,(long)pwr.statsFumbles,(long)pwr.statsRecYards]];
+    if (heisman != nil && heismanWinnerStrFull != nil && heismanWinnerStrFull.length != 0) {
+        heisman.isHeisman = YES;
+        return heismanWinnerStrFull;
+    } else {
+        BOOL putNewsStory = false;
+        
+        heismanCandidates = [[self calculateHeismanCandidates] mutableCopy];
+        heisman = heismanCandidates[0];
+        heismanDecided = true;
+        putNewsStory = true;
+        
+        NSString* heismanTop5 = @"\n";
+        NSMutableString* heismanStats = [NSMutableString string];
+        NSString* heismanWinnerStr = @"";
+        heismanFinalists = [NSMutableArray array];
+        //full results string
+        int i = 0;
+        int place = 1;
+        while (heismanFinalists.count < 5 && i < heismanCandidates.count) {
+            Player *p = heismanCandidates[i];
+            heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@"%d. %@ (%ld-%ld) - ",place,p.team.abbreviation,(long)p.team.wins,(long)p.team.losses]];
+            if ([p isKindOfClass:[PlayerQB class]]) {
+                PlayerQB *pqb = (PlayerQB*)p;
+                heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" QB %@: %ld votes\n\t(%ld TDs, %ld Int, %ld Yds)\n",[pqb getInitialName],(long)[pqb getHeismanScore],(long)pqb.statsTD,(long)pqb.statsInt,(long)pqb.statsPassYards]];
+            } else if ([p isKindOfClass:[PlayerRB class]]) {
+                PlayerRB *prb = (PlayerRB*)p;
+                heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" RB %@: %ld votes\n\t(%ld TDs, %ld Fum, %ld Yds)\n",[prb getInitialName],(long)[prb getHeismanScore],(long)prb.statsTD,(long)prb.statsFumbles,(long)prb.statsRushYards]];
+            } else if ([p isKindOfClass:[PlayerWR class]]) {
+                PlayerWR *pwr = (PlayerWR*)p;
+                heismanTop5 = [heismanTop5 stringByAppendingString:[NSString stringWithFormat:@" WR %@: %ld votes\n\t(%ld TDs, %ld Fum, %ld Yds)\n",[pwr getInitialName],(long)[pwr getHeismanScore],(long)pwr.statsTD,(long)pwr.statsFumbles,(long)pwr.statsRecYards]];
+            }
+            if (p != nil && ![heismanFinalists containsObject:p]) {
+                [heismanFinalists addObject:p];
+                place++;
+            }
+            i++;
         }
-        if (p != nil && ![heismanFinalists containsObject:p]) {
-            [heismanFinalists addObject:p];
-            place++;
+        
+        heisman.team.heismans++;
+        heisman.careerHeismans++;
+        heisman.isHeisman = YES;
+        if ([heisman isKindOfClass:[PlayerQB class]]) {
+            //qb heisman
+            PlayerQB *heisQB = (PlayerQB*)heisman;
+            if (heisQB.statsInt > 1 || heisQB.statsInt == 0) {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ QB %@!\n?Congratulations to %@ QB %@ [%@], who had %ld TDs, %ld interceptions, and %ld passing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisQB.team.abbreviation, [heisQB getInitialName],heisQB.team.abbreviation, heisQB.name, [heisman getYearString], (long)heisQB.statsTD, (long)heisQB.statsInt, (long)heisQB.statsPassYards, heisQB.team.name, (long)heisQB.team.wins,(long)heisQB.team.losses,(long)heisQB.team.rankTeamPollScore];
+            } else {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ QB %@!\n?Congratulations to %@ QB %@ [%@], who had %ld TDs, %ld interception, and %ld passing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisQB.team.abbreviation, [heisQB getInitialName],heisQB.team.abbreviation, heisQB.name, [heisman getYearString], (long)heisQB.statsTD, (long)heisQB.statsInt, (long)heisQB.statsPassYards, heisQB.team.name, (long)heisQB.team.wins,(long)heisQB.team.losses,(long)heisQB.team.rankTeamPollScore];
+            }
+            
+            [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
+        } else if ([heisman isKindOfClass:[PlayerRB class]]) {
+            //rb heisman
+            PlayerRB *heisRB = (PlayerRB*)heisman;
+            if (heisRB.statsFumbles > 1 || heisRB.statsFumbles == 0) {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ RB %@!\n?Congratulations to %@ RB %@ [%@], who had %ld TDs, %ld fumbles, and %ld rushing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisRB.team.abbreviation, [heisRB getInitialName], heisRB.team.abbreviation, heisRB.name, [heisman getYearString], (long)heisRB.statsTD, (long)heisRB.statsFumbles, (long)heisRB.statsRushYards, heisRB.team.name, (long)heisRB.team.wins,(long)heisRB.team.losses,(long)heisRB.team.rankTeamPollScore];
+            } else {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ RB %@!\n?Congratulations to %@ RB %@ [%@], who had %ld TDs, %ld fumble, and %ld rushing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisRB.team.abbreviation, [heisRB getInitialName],heisRB.team.abbreviation, heisRB.name, [heisman getYearString], (long)heisRB.statsTD, (long)heisRB.statsFumbles, (long)heisRB.statsRushYards, heisRB.team.name, (long)heisRB.team.wins,(long)heisRB.team.losses,(long)heisRB.team.rankTeamPollScore];
+            }
+            [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
+        } else if ([heisman isKindOfClass:[PlayerWR class]]) {
+            //wr heisman
+            PlayerWR *heisWR = (PlayerWR*)heisman;
+            if (heisWR.statsFumbles > 1 || heisWR.statsFumbles == 0) {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ WR %@!\n?Congratulations to %@ WR %@ [%@], who had %ld TDs, %ld fumbles, and %ld receiving yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisWR.team.abbreviation, [heisWR getInitialName], heisWR.team.abbreviation, heisWR.name, [heisman getYearString], (long)heisWR.statsTD, (long)heisWR.statsFumbles, (long)heisWR.statsRecYards, heisWR.team.name, (long)heisWR.team.wins,(long)heisWR.team.losses,(long)heisWR.team.rankTeamPollScore];
+            } else {
+                heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ WR %@!\n?Congratulations to %@ WR %@ [%@], who had %ld TDs, %ld fumble, and %ld receiving yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisWR.team.abbreviation, [heisWR getInitialName],heisWR.team.abbreviation, heisWR.name, [heisman getYearString], (long)heisWR.statsTD, (long)heisWR.statsFumbles, (long)heisWR.statsRecYards, heisWR.team.name, (long)heisWR.team.wins,(long)heisWR.team.losses,(long)heisWR.team.rankTeamPollScore];
+            }
+            
+            [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
         }
-        i++;
+        
+        // Add news story
+        if (putNewsStory) {
+            NSMutableArray *week13 = newsStories[13];
+            NSString *newsString = [heismanWinnerStr stringByReplacingOccurrencesOfString:@"?" withString:@""];
+            if (![week13 containsObject:newsString]) {
+                [week13 addObject:newsString];
+            }
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"newNewsStory" object:nil];
+        }
+        
+        heismanWinnerStrFull = heismanStats;
+        return heismanStats;
     }
-
-//    heisman.team.heismans++;
-//    heisman.careerHeismans++;
-    heisman.isHeisman = YES;
-    if ([heisman isKindOfClass:[PlayerQB class]]) {
-        //qb heisman
-        PlayerQB *heisQB = (PlayerQB*)heisman;
-        if (heisQB.statsInt > 1 || heisQB.statsInt == 0) {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ QB %@!\n?Congratulations to %@ QB %@ [%@], who had %ld TDs, %ld interceptions, and %ld passing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisQB.team.abbreviation, [heisQB getInitialName],heisQB.team.abbreviation, heisQB.name, [heisman getYearString], (long)heisQB.statsTD, (long)heisQB.statsInt, (long)heisQB.statsPassYards, heisQB.team.name, (long)heisQB.team.wins,(long)heisQB.team.losses,(long)heisQB.team.rankTeamPollScore];
-        } else {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ QB %@!\n?Congratulations to %@ QB %@ [%@], who had %ld TDs, %ld interception, and %ld passing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisQB.team.abbreviation, [heisQB getInitialName],heisQB.team.abbreviation, heisQB.name, [heisman getYearString], (long)heisQB.statsTD, (long)heisQB.statsInt, (long)heisQB.statsPassYards, heisQB.team.name, (long)heisQB.team.wins,(long)heisQB.team.losses,(long)heisQB.team.rankTeamPollScore];
-        }
-
-        [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
-    } else if ([heisman isKindOfClass:[PlayerRB class]]) {
-        //rb heisman
-        PlayerRB *heisRB = (PlayerRB*)heisman;
-        if (heisRB.statsFumbles > 1 || heisRB.statsFumbles == 0) {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ RB %@!\n?Congratulations to %@ RB %@ [%@], who had %ld TDs, %ld fumbles, and %ld rushing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisRB.team.abbreviation, [heisRB getInitialName], heisRB.team.abbreviation, heisRB.name, [heisman getYearString], (long)heisRB.statsTD, (long)heisRB.statsFumbles, (long)heisRB.statsRushYards, heisRB.team.name, (long)heisRB.team.wins,(long)heisRB.team.losses,(long)heisRB.team.rankTeamPollScore];
-        } else {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ RB %@!\n?Congratulations to %@ RB %@ [%@], who had %ld TDs, %ld fumble, and %ld rushing yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisRB.team.abbreviation, [heisRB getInitialName],heisRB.team.abbreviation, heisRB.name, [heisman getYearString], (long)heisRB.statsTD, (long)heisRB.statsFumbles, (long)heisRB.statsRushYards, heisRB.team.name, (long)heisRB.team.wins,(long)heisRB.team.losses,(long)heisRB.team.rankTeamPollScore];
-        }
-        [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
-    } else if ([heisman isKindOfClass:[PlayerWR class]]) {
-        //wr heisman
-        PlayerWR *heisWR = (PlayerWR*)heisman;
-        if (heisWR.statsFumbles > 1 || heisWR.statsFumbles == 0) {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ WR %@!\n?Congratulations to %@ WR %@ [%@], who had %ld TDs, %ld fumbles, and %ld receiving yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisWR.team.abbreviation, [heisWR getInitialName], heisWR.team.abbreviation, heisWR.name, [heisman getYearString], (long)heisWR.statsTD, (long)heisWR.statsFumbles, (long)heisWR.statsRecYards, heisWR.team.name, (long)heisWR.team.wins,(long)heisWR.team.losses,(long)heisWR.team.rankTeamPollScore];
-        } else {
-            heismanWinnerStr = [NSString stringWithFormat:@"%ld's POTY: %@ WR %@!\n?Congratulations to %@ WR %@ [%@], who had %ld TDs, %ld fumble, and %ld receiving yards and led %@ to a %ld-%ld record and a #%ld poll ranking.",(long)([HBSharedUtils currentLeague].baseYear + self.leagueHistoryDictionary.count), heisWR.team.abbreviation, [heisWR getInitialName],heisWR.team.abbreviation, heisWR.name, [heisman getYearString], (long)heisWR.statsTD, (long)heisWR.statsFumbles, (long)heisWR.statsRecYards, heisWR.team.name, (long)heisWR.team.wins,(long)heisWR.team.losses,(long)heisWR.team.rankTeamPollScore];
-        }
-
-        [heismanStats appendString:[NSString stringWithFormat:@"%@\n\nFull Results: %@",heismanWinnerStr, heismanTop5]];
-    }
-
-    // Add news story
-    if (putNewsStory) {
-        NSMutableArray *week13 = newsStories[13];
-        NSString *newsString = [heismanWinnerStr stringByReplacingOccurrencesOfString:@"?" withString:@""];
-        if (![week13 containsObject:newsString]) {
-            [week13 addObject:newsString];
-        }
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"newNewsStory" object:nil];
-    }
-
-    heismanWinnerStrFull = heismanStats;
-    return heismanStats;
 }
 
 -(NSArray*)getBowlPredictions {

--- a/harbaughsim16/League.m
+++ b/harbaughsim16/League.m
@@ -1505,8 +1505,8 @@
         i++;
     }
 
-    heisman.team.heismans++;
-    heisman.careerHeismans++;
+//    heisman.team.heismans++;
+//    heisman.careerHeismans++;
     heisman.isHeisman = YES;
     if ([heisman isKindOfClass:[PlayerQB class]]) {
         //qb heisman

--- a/harbaughsim16/League.m
+++ b/harbaughsim16/League.m
@@ -1990,13 +1990,13 @@
         } else if ([a isKindOfClass:[PlayerRB class]]) {
             PlayerRB *p = (PlayerRB*)a;
             adjADraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRushEva + p.ratRushPow + p.ratRushSpd + adjAHeisScore) / 6.0) * 12.0);
-        } else if ([a isKindOfClass:[PlayerWR class]]) {
-            PlayerWR *p = (PlayerWR*)a;
-            adjADraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratRecEva + p.ratRecSpd + adjAHeisScore) / 6.0) * 12.0);
         } else if ([a isKindOfClass:[PlayerTE class]]) {
             PlayerTE *p = (PlayerTE*)a;
             adjADraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratTERunBlk + p.ratRecSpd + adjAHeisScore) / 6.0) * 12.0);
-        } else if ([a isKindOfClass:[PlayerOL class]]) {
+        } else if ([a isKindOfClass:[PlayerWR class]]) {
+            PlayerWR *p = (PlayerWR*)a;
+            adjADraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratRecEva + p.ratRecSpd + adjAHeisScore) / 6.0) * 12.0);
+        }else if ([a isKindOfClass:[PlayerOL class]]) {
             PlayerOL *p = (PlayerOL*)a;
             adjADraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratOLBkP + p.ratOLPow + p.ratOLBkR) / 5.0) * 11.0);
         } else if ([a isKindOfClass:[PlayerDL class]]) {
@@ -2023,12 +2023,12 @@
         } else if ([b isKindOfClass:[PlayerRB class]]) {
             PlayerRB *p = (PlayerRB*)b;
             adjBDraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRushEva + p.ratRushPow + p.ratRushSpd  + adjBHeisScore) / 6.0) * 12.0);
-        } else if ([b isKindOfClass:[PlayerWR class]]) {
-            PlayerWR *p = (PlayerWR*)b;
-            adjBDraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratRecEva + p.ratRecSpd + adjBHeisScore) / 6.0) * 12.0);
         } else if ([b isKindOfClass:[PlayerTE class]]) {
             PlayerTE *p = (PlayerTE*)b;
             adjBDraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratTERunBlk + p.ratRecSpd + adjBHeisScore) / 6.0) * 12.0);
+        } else if ([b isKindOfClass:[PlayerWR class]]) {
+            PlayerWR *p = (PlayerWR*)b;
+            adjBDraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratRecCat + p.ratRecEva + p.ratRecSpd + adjBHeisScore) / 6.0) * 12.0);
         } else if ([b isKindOfClass:[PlayerOL class]]) {
             PlayerOL *p = (PlayerOL*)b;
             adjBDraftGrade = (int)(((double)(p.ratOvr + p.ratFootIQ + p.ratOLBkP + p.ratOLPow + p.ratOLBkR) / 5.0) * 11.0);

--- a/harbaughsim16/League.m
+++ b/harbaughsim16/League.m
@@ -1270,7 +1270,7 @@
             curseTeam = teamList[3 + curseNumber];
         }
         
-        if (!curseTeam.isUserControlled && curseTeam.teamPrestige > 85) {
+        if (!curseTeam.isUserControlled) {
             curseTeam.teamPrestige -= 20;
             cursedTeam = curseTeam;
         }
@@ -1282,6 +1282,11 @@
         
         if (curseTeam.teamPrestige > 85) {
             curseTeam.teamPrestige -= 20;
+            if ([curseTeam.name isEqualToString:@"American Samoa"]) {
+                curseTeam.teamPrestige = MAX(0, curseTeam.teamPrestige);
+            } else {
+                curseTeam.teamPrestige = MAX(25, curseTeam.teamPrestige);
+            }
             cursedTeam = curseTeam;
         }
     }

--- a/harbaughsim16/League.m
+++ b/harbaughsim16/League.m
@@ -1247,6 +1247,7 @@
     currentWeek = 0;
     ncg = nil;
     heisman = nil;
+    heismanWinnerStrFull = nil;
     // Bless a random team with lots of prestige
     int blessNumber = (int)([HBSharedUtils randomValue]*9);
     Team *blessTeam = teamList[50 + blessNumber];

--- a/harbaughsim16/MyTeamViewController.xib
+++ b/harbaughsim16/MyTeamViewController.xib
@@ -38,7 +38,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Prestige: A+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jjt-YK-FYs">
-                    <rect key="frame" x="8" y="36" width="84" height="21"/>
+                    <rect key="frame" x="8" y="36" width="84" height="25"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
@@ -61,7 +61,7 @@
                 <constraint firstAttribute="trailing" secondItem="C0m-aE-2wG" secondAttribute="trailing" constant="8" id="gbz-45-gfk"/>
                 <constraint firstItem="bBE-Z3-kUp" firstAttribute="bottom" secondItem="C0m-aE-2wG" secondAttribute="bottom" id="nK3-5D-h3g"/>
                 <constraint firstItem="jjt-YK-FYs" firstAttribute="top" secondItem="bBE-Z3-kUp" secondAttribute="bottom" constant="2" id="rit-FI-oq2"/>
-                <constraint firstItem="jjt-YK-FYs" firstAttribute="bottom" secondItem="Dyy-ML-bUT" secondAttribute="bottomMargin" constant="-8" id="yLR-Rg-hIa"/>
+                <constraint firstItem="jjt-YK-FYs" firstAttribute="bottom" secondItem="Dyy-ML-bUT" secondAttribute="bottomMargin" constant="-4" id="yLR-Rg-hIa"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/harbaughsim16/Player.m
+++ b/harbaughsim16/Player.m
@@ -513,7 +513,7 @@
     int playbookScore = 0;
     if ([self.position isEqualToString:@"QB"] || [self.position isEqualToString:@"RB"] || [self.position isEqualToString:@"WR"] || [self.position isEqualToString:@"TE"] || [self.position isEqualToString:@"OL"]) {
         // use offensive playbook
-        TeamStrategy *offStrat = t.defensiveStrategy;
+        TeamStrategy *offStrat = t.offensiveStrategy;
         if ([self.position isEqualToString:@"QB"]) {
             playbookScore = 15; // always need a good QB & super important to offensive playbook
         } else if ([self.position isEqualToString:@"WR"] || [self.position isEqualToString:@"TE"]) {
@@ -548,9 +548,9 @@
             }
         }
     }
-    
-    //NSLog(@"Location Score: %d Positional Score: %d Prestige Score: %d Playbook Score: %d", locationScore,positionalScore, prestigeScore, playbookScore);
-    return locationScore + positionalScore + prestigeScore + playbookScore;
+    int sum = locationScore + positionalScore + prestigeScore + playbookScore;
+    //NSLog(@"Location Score: %d Positional Score: %d Prestige Score: %d Playbook Score: %d => TOTAL %@ INTEREST: %d", locationScore,positionalScore, prestigeScore, playbookScore, position, sum);
+    return sum;
 }
 
 -(NSString *)uniqueIdentifier {

--- a/harbaughsim16/Player.m
+++ b/harbaughsim16/Player.m
@@ -337,6 +337,12 @@
 -(void)advanceSeason {
     self.year++;
     self.gamesPlayedSeason = 0;
+    
+    if (self.isHeisman) {
+        self.team.heismans++;
+        self.careerHeismans++;
+    }
+    
     self.isHeisman = NO;
     self.isAllAmerican = NO;
     self.isAllConference = NO;
@@ -345,6 +351,7 @@
         self.hasRedshirt = NO;
         self.wasRedshirted = YES;
     }
+    
 }
 
 -(int)getHeismanScore {

--- a/harbaughsim16/Player.m
+++ b/harbaughsim16/Player.m
@@ -338,10 +338,10 @@
     self.year++;
     self.gamesPlayedSeason = 0;
     
-    if (self.isHeisman) {
-        self.team.heismans++;
-        self.careerHeismans++;
-    }
+//    if (self.isHeisman) {
+//        self.team.heismans++;
+//        self.careerHeismans++;
+//    }
     
     self.isHeisman = NO;
     self.isAllAmerican = NO;

--- a/harbaughsim16/PlayerStatsViewController.m
+++ b/harbaughsim16/PlayerStatsViewController.m
@@ -84,6 +84,7 @@
         self.title = @"Rushing Leaders";
         for (Team *t in [HBSharedUtils currentLeague].teamList) {
             [players addObjectsFromArray:t.teamRBs];
+            [players addObjectsFromArray:t.teamQBs];
         }
         
         [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
@@ -188,65 +189,176 @@
     } else if (position == HBStatPositionRB) { //Yds, att, YPG, TD, Fum
         [alertController addAction:[UIAlertAction actionWithTitle:@"Rushing Yards" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-                PlayerRB *a = (PlayerRB*)obj1;
-                PlayerRB *b = (PlayerRB*)obj2;
-                return (a.statsRushYards > b.statsRushYards) ? -1 : ((a.statsRushYards == b.statsRushYards) ? [a.name compare:b.name] : 1);
+                Player *a = (Player*)obj1;
+                Player *b = (Player*)obj2;
+                if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+                    int aYards;
+                    int bYards;
+                    if ([a isKindOfClass:[PlayerQB class]]) {
+                        aYards = ((PlayerQB*)a).statsRushYards;
+                    } else if ([a isKindOfClass:[PlayerRB class]]) {
+                        aYards = ((PlayerRB*)a).statsRushYards;
+                    } else {
+                        aYards = 0;
+                    }
+                    
+                    if ([b isKindOfClass:[PlayerQB class]]) {
+                        bYards = ((PlayerQB*)b).statsRushYards;
+                    } else if ([b isKindOfClass:[PlayerRB class]]) {
+                        bYards = ((PlayerRB*)b).statsRushYards;
+                    } else {
+                        bYards = 0;
+                    }
+                    
+                    return (aYards > bYards) ? -1 : ((aYards == bYards) ? [a.name compare:b.name] : 1);
+                } else {
+                    return [a.name compare:b.name];
+                }
             }];
             [self.tableView reloadData];
         }]];
         
         [alertController addAction:[UIAlertAction actionWithTitle:@"Yards per Attempt" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-                PlayerRB *a = (PlayerRB*)obj1;
-                PlayerRB *b = (PlayerRB*)obj2;
                 int aYPA = 0;
-                if (a.statsRushAtt > 0) {
-                    aYPA = (int)ceil((double)a.statsRushYards/(double)a.statsRushAtt);
-                }
-                
                 int bYPA = 0;
-                if (b.statsRushAtt > 0) {
-                    bYPA = (int)ceil((double)b.statsRushYards/(double)b.statsRushAtt);
-                }
+
+                Player *a = (Player*)obj1;
+                Player *b = (Player*)obj2;
+                if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+                    if ([a isKindOfClass:[PlayerQB class]]) {
+                        if (((PlayerQB*)a).statsRushAtt > 0) {
+                            aYPA = (int)ceil((double) ((PlayerRB*)a).statsRushYards/(double) ((PlayerRB*)a).statsRushAtt);
+                        }
+                    } else if ([a isKindOfClass:[PlayerRB class]]) {
+                        if (((PlayerRB*)a).statsRushAtt > 0) {
+                            aYPA = (int)ceil((double) ((PlayerRB*)a).statsRushYards/(double) ((PlayerRB*)a).statsRushAtt);
+                        }
+                    } else {
+                        aYPA = 0;
+                    }
+                    
+                    if ([b isKindOfClass:[PlayerQB class]]) {
+                        if (((PlayerQB*)b).statsRushAtt > 0) {
+                            bYPA = (int)ceil((double) ((PlayerRB*)b).statsRushYards/(double) ((PlayerRB*)b).statsRushAtt);
+                        }
+                    } else if ([b isKindOfClass:[PlayerRB class]]) {
+                        if (((PlayerRB*)b).statsRushAtt > 0) {
+                            bYPA = (int)ceil((double) ((PlayerRB*)b).statsRushYards/(double) ((PlayerRB*)b).statsRushAtt);
+                        }
+                    } else {
+                        bYPA = 0;
+                    }
+                    
                 
-                return (aYPA > bYPA) ? -1 : ((aYPA == bYPA) ? [a.name compare:b.name] : 1);
+                    return (aYPA > bYPA) ? -1 : ((aYPA == bYPA) ? [a.name compare:b.name] : 1);
+                } else {
+                    return [a.name compare:b.name];
+                }
             }];
             [self.tableView reloadData];
         }]];
         
         [alertController addAction:[UIAlertAction actionWithTitle:@"Yards per Game" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-                PlayerRB *a = (PlayerRB*)obj1;
-                PlayerRB *b = (PlayerRB*)obj2;
                 int aYPG = 0;
-                if (a.gamesPlayed > 0) {
-                    aYPG = (int)ceil((double)a.statsRushYards/(double)a.gamesPlayed);
-                }
-                
                 int bYPG = 0;
-                if (b.gamesPlayed > 0) {
-                    bYPG = (int)ceil((double)b.statsRushYards/(double)b.gamesPlayed);
-                }
                 
-                return (aYPG > bYPG) ? -1 : ((aYPG == bYPG) ? [a.name compare:b.name] : 1);
+                Player *a = (Player*)obj1;
+                Player *b = (Player*)obj2;
+                if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+                    if ([a isKindOfClass:[PlayerQB class]]) {
+                        if (((PlayerQB*)a).gamesPlayed > 0) {
+                            aYPG = (int)ceil((double) ((PlayerRB*)a).statsRushYards/(double) ((PlayerRB*)a).gamesPlayed);
+                        }
+                    } else if ([a isKindOfClass:[PlayerRB class]]) {
+                        if (((PlayerRB*)a).gamesPlayed > 0) {
+                            aYPG = (int)ceil((double) ((PlayerRB*)a).statsRushYards/(double) ((PlayerRB*)a).gamesPlayed);
+                        }
+                    } else {
+                        aYPG = 0;
+                    }
+                    
+                    if ([b isKindOfClass:[PlayerQB class]]) {
+                        if (((PlayerQB*)b).gamesPlayed > 0) {
+                            bYPG = (int)ceil((double) ((PlayerRB*)b).statsRushYards/(double) ((PlayerRB*)b).gamesPlayed);
+                        }
+                    } else if ([b isKindOfClass:[PlayerRB class]]) {
+                        if (((PlayerRB*)b).gamesPlayed > 0) {
+                            bYPG = (int)ceil((double) ((PlayerRB*)b).statsRushYards/(double) ((PlayerRB*)b).gamesPlayed);
+                        }
+                    } else {
+                        bYPG = 0;
+                    }
+                    
+                    
+                    return (aYPG > bYPG) ? -1 : ((aYPG == bYPG) ? [a.name compare:b.name] : 1);
+                } else {
+                    return [a.name compare:b.name];
+                }
             }];
             [self.tableView reloadData];
         }]];
         
         [alertController addAction:[UIAlertAction actionWithTitle:@"Touchdowns" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-                PlayerRB *a = (PlayerRB*)obj1;
-                PlayerRB *b = (PlayerRB*)obj2;
-                return (a.statsTD > b.statsTD) ? -1 : ((a.statsTD == b.statsTD) ? [a.name compare:b.name] : 1);
+                Player *a = (Player*)obj1;
+                Player *b = (Player*)obj2;
+                if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+                    int aTD = 0;
+                    int bTD = 0;
+                    
+                    if ([a isKindOfClass:[PlayerQB class]]) {
+                        aTD = ((PlayerQB*)a).statsRushTD;
+                    } else if ([a isKindOfClass:[PlayerRB class]]) {
+                        aTD = ((PlayerRB*)a).statsTD;
+                    } else {
+                        aTD = 0;
+                    }
+                    
+                    if ([b isKindOfClass:[PlayerQB class]]) {
+                        bTD = ((PlayerQB*)b).statsRushTD;
+                    } else if ([b isKindOfClass:[PlayerRB class]]) {
+                        bTD = ((PlayerRB*)b).statsTD;
+                    } else {
+                        bTD = 0;
+                    }
+                    
+                    return (aTD > bTD) ? -1 : ((aTD == bTD) ? [a.name compare:b.name] : 1);
+                } else {
+                    return [a.name compare:b.name];
+                }
             }];
             [self.tableView reloadData];
         }]];
         
         [alertController addAction:[UIAlertAction actionWithTitle:@"Fumbles" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
             [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-                PlayerRB *a = (PlayerRB*)obj1;
-                PlayerRB *b = (PlayerRB*)obj2;
-                return (a.statsFumbles > b.statsFumbles) ? -1 : ((a.statsFumbles == b.statsFumbles) ? [a.name compare:b.name] : 1);
+                Player *a = (Player*)obj1;
+                Player *b = (Player*)obj2;
+                if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+                    int aFumbles = 0;
+                    int bFumbles = 0;
+                    if ([a isKindOfClass:[PlayerQB class]]) {
+                        aFumbles = ((PlayerQB*)a).statsFumbles;
+                    } else if ([a isKindOfClass:[PlayerRB class]]) {
+                        aFumbles = ((PlayerRB*)a).statsFumbles;
+                    } else {
+                        aFumbles = 0;
+                    }
+                    
+                    if ([b isKindOfClass:[PlayerQB class]]) {
+                        bFumbles = ((PlayerQB*)b).statsFumbles;
+                    } else if ([b isKindOfClass:[PlayerRB class]]) {
+                        bFumbles = ((PlayerRB*)b).statsFumbles;
+                    } else {
+                        bFumbles = 0;
+                    }
+                    
+                    return (aFumbles > bFumbles) ? -1 : ((aFumbles == bFumbles) ? [a.name compare:b.name] : 1);
+                } else {
+                    return [a.name compare:b.name];
+                }
             }];
             [self.tableView reloadData];
         }]];
@@ -401,7 +513,7 @@
     NSString *stat3Value = @"";
     NSString *stat4Value = @"";
     
-    if ([plyr isKindOfClass:[PlayerQB class]]) {
+    if (position == HBStatPositionQB) {
         stat1 = @"CMP%"; //comp/att, yds, td, int
         stat2 = @"Yds";
         stat3 = @"TDs";
@@ -413,17 +525,24 @@
         stat3Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsTD];
         stat4Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsInt];
         //[statsCell.stat1ValueLabel setFont:[UIFont systemFontOfSize:13.0]];
-    } else if ([plyr isKindOfClass:[PlayerRB class]]) {
+    } else if (position == HBStatPositionRB) {
         stat1 = @"Car";
         stat2 = @"Yds";
         stat3 = @"TD";
         stat4 = @"Fum";
-        stat1Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsRushAtt];
-        stat2Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsRushYards];
-        stat3Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsTD];
-        stat4Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsFumbles];
+        if ([plyr isKindOfClass:[PlayerQB class]]) {
+            stat1Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsRushAtt];
+            stat2Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsRushYards];
+            stat3Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsRushTD];
+            stat4Value = [NSString stringWithFormat:@"%d",((PlayerQB*)plyr).statsFumbles];
+        } else {
+            stat1Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsRushAtt];
+            stat2Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsRushYards];
+            stat3Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsTD];
+            stat4Value = [NSString stringWithFormat:@"%d",((PlayerRB*)plyr).statsFumbles];
+        }
         //[statsCell.stat1ValueLabel setFont:[UIFont systemFontOfSize:17.0]];
-    } else if ([plyr isKindOfClass:[PlayerWR class]]) {
+    } else if (position == HBStatPositionWR) {
         stat1 = @"Rec";
         stat2 = @"Yds";
         stat3 = @"TD";

--- a/harbaughsim16/PlayerStatsViewController.m
+++ b/harbaughsim16/PlayerStatsViewController.m
@@ -97,6 +97,7 @@
         self.title = @"Receiving Leaders";
         for (Team *t in [HBSharedUtils currentLeague].teamList) {
             [players addObjectsFromArray:t.teamWRs];
+            [players addObjectsFromArray:t.teamTEs];
         }
         
         [players sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {

--- a/harbaughsim16/RankingsViewController.m
+++ b/harbaughsim16/RankingsViewController.m
@@ -234,7 +234,7 @@
     Team *t = teams[indexPath.row];
     [cell.textLabel setText:[NSString stringWithFormat:@"#%ld: %@ (%ld-%ld)", (long)(indexPath.row + 1), t.name,(long)t.wins,(long)t.losses]];
     
-    if ([HBSharedUtils currentLeague].userTeam != nil && [HBSharedUtils currentLeague].userTeam.name != nil && [cell.textLabel.text containsString:[HBSharedUtils currentLeague].userTeam.name]) {
+    if ([HBSharedUtils currentLeague].userTeam != nil && [HBSharedUtils currentLeague].userTeam.name != nil && [t.name isEqualToString:[HBSharedUtils currentLeague].userTeam.name]) {
         [cell.textLabel setTextColor:[HBSharedUtils styleColor]];
     } else {
         [cell.textLabel setTextColor:[UIColor blackColor]];

--- a/harbaughsim16/RecruitingPeriodViewController.m
+++ b/harbaughsim16/RecruitingPeriodViewController.m
@@ -751,7 +751,7 @@
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Next" style:UIBarButtonItemStylePlain target:self action:@selector(advanceRecruits)];
 
     // calculate recruiting points, but never show number - just show as usage as "% effort extended"
-    recruitingPoints = ([HBSharedUtils currentLeague].isHardMode) ? (int)ceilf(20.0 * [HBSharedUtils currentLeague].userTeam.teamPrestige) : (int)ceilf(25.0 * [HBSharedUtils currentLeague].userTeam.teamPrestige);
+    recruitingPoints = MAX(([HBSharedUtils currentLeague].isHardMode) ? (int)ceilf(20.0 * [HBSharedUtils currentLeague].userTeam.teamPrestige) : (int)ceilf(25.0 * [HBSharedUtils currentLeague].userTeam.teamPrestige), 600);
     usedRecruitingPoints = 0;
 
     NSLog(@"Recruiting points total: %d", recruitingPoints);

--- a/harbaughsim16/RecruitingPeriodViewController.m
+++ b/harbaughsim16/RecruitingPeriodViewController.m
@@ -1305,7 +1305,11 @@
             }
         }
     } else {
-        p = currentRecruits[indexPath.row];
+        @synchronized(currentRecruits) {
+            if (indexPath.row < currentRecruits.count) {
+                p = currentRecruits[indexPath.row];
+            }
+        }
     }
     
     CFCRecruitCell *cell = [tableView dequeueReusableCellWithIdentifier:@"CFCRecruitCell"];
@@ -1492,7 +1496,11 @@
             }
         }
     } else {
-        p = currentRecruits[indexPath.row];
+        @synchronized(currentRecruits) {
+            if (indexPath.row < currentRecruits.count) {
+                p = currentRecruits[indexPath.row];
+            }
+        }
     }
     if (p != nil) {
         NSMutableArray *recruitEvents = ([recruitActivities.allKeys containsObject:[p uniqueIdentifier]]) ? recruitActivities[[p uniqueIdentifier]] : [NSMutableArray array];

--- a/harbaughsim16/Team.m
+++ b/harbaughsim16/Team.m
@@ -2137,7 +2137,7 @@
             if (teamTEs[i].year >= 4 || (teamTEs[i].year == 3 && teamTEs[i].gamesPlayed && teamTEs[i].ratOvr > NFL_OVR && [HBSharedUtils randomValue] < draftChance)) {
                 [playersLeaving addObject:teamTEs[i]];
                 if (teamTEs[i].year == 3) {
-                    NSLog(@"JUNIOR WR LEAVING");
+                    NSLog(@"JUNIOR TE LEAVING");
                 }
             }
             ++i;

--- a/harbaughsim16/TeamViewController.m
+++ b/harbaughsim16/TeamViewController.m
@@ -117,17 +117,17 @@
     NSString *abbrev = [textFields[1].text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     NSString *state = [textFields[2].text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     
-    if (![name isEqualToString:selTeam.name] && [selTeam.league isTeamNameValid:name allowUserTeam:NO allowOverwrite:NO]) {
+    if (![name isEqualToString:selTeam.name] && [selTeam.league isTeamNameValid:name allowUserTeam:YES allowOverwrite:NO]) {
         [selectedTeam setName:name];
         [[HBSharedUtils currentLeague] save];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"newTeamName" object:nil];
         [self.tableView reloadData];
-    } else if (![selTeam.league isTeamNameValid:name allowUserTeam:NO allowOverwrite:NO]) {
+    } else if (![name isEqualToString:selTeam.name] && ![selTeam.league isTeamNameValid:name allowUserTeam:YES allowOverwrite:NO]) {
         [HBSharedUtils showNotificationWithTintColor:[HBSharedUtils errorColor] title:@"Error" message:@"Unable to update this team's information - invalid team name provided" onViewController:self];
         return;
     }
     
-    if (![abbrev isEqualToString:selTeam.abbreviation] && [selTeam.league isTeamAbbrValid:abbrev allowUserTeam:NO allowOverwrite:NO]) {
+    if (![abbrev isEqualToString:selTeam.abbreviation] && [selTeam.league isTeamAbbrValid:abbrev allowUserTeam:YES allowOverwrite:NO]) {
         [selectedTeam setAbbreviation:abbrev];
         [[HBSharedUtils currentLeague] save];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"newTeamName" object:nil];
@@ -174,7 +174,7 @@
                 [[HBSharedUtils currentLeague].heismanHistoryDictionary setObject:heisString forKey:[NSString stringWithFormat:@"%ld",(long)([HBSharedUtils currentLeague].baseYear + j)]];
             }
         }
-    } else if (![selTeam.league isTeamAbbrValid:abbrev allowUserTeam:NO allowOverwrite:NO]) {
+    } else if (![abbrev isEqualToString:selTeam.abbreviation] && ![selTeam.league isTeamAbbrValid:abbrev allowUserTeam:YES allowOverwrite:NO]) {
         [HBSharedUtils showNotificationWithTintColor:[HBSharedUtils errorColor] title:@"Error" message:@"Unable to update this team's information - invalid team abbreviation provided" onViewController:self];
         return;
     }

--- a/harbaughsim16/TeamViewController.xib
+++ b/harbaughsim16/TeamViewController.xib
@@ -1,8 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TeamViewController">
@@ -13,9 +18,9 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" bouncesZoom="NO" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <connections>
                 <outlet property="dataSource" destination="-1" id="Tng-2m-Rnh"/>
                 <outlet property="delegate" destination="-1" id="9aC-8N-iBw"/>
@@ -29,30 +34,30 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Yellowstone St" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NvX-3L-gK2">
                     <rect key="frame" x="8" y="11" width="120.5" height="23"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Prestige: A+" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jRn-wV-80l">
-                    <rect key="frame" x="8" y="36" width="84" height="21"/>
+                    <rect key="frame" x="8" y="36" width="84" height="25"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2016: 10-3" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QXb-cD-1CI">
                     <rect key="frame" x="237" y="11" width="75" height="23"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                    <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" red="0.23921568630000001" green="0.70196078429999997" blue="0.61960784310000006" alpha="1" colorSpace="calibratedRGB"/>
+            <color key="backgroundColor" red="0.23921568630000001" green="0.70196078429999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="jRn-wV-80l" firstAttribute="leading" secondItem="NvX-3L-gK2" secondAttribute="leading" id="DLf-Cp-DeW"/>
                 <constraint firstItem="jRn-wV-80l" firstAttribute="top" secondItem="NvX-3L-gK2" secondAttribute="bottom" constant="2" id="GOc-NZ-oeE"/>
                 <constraint firstAttribute="trailing" secondItem="QXb-cD-1CI" secondAttribute="trailing" constant="8" id="Nym-tw-TTt"/>
                 <constraint firstItem="NvX-3L-gK2" firstAttribute="top" secondItem="jxW-8A-zuT" secondAttribute="top" constant="11" id="PxV-s5-11D"/>
                 <constraint firstItem="NvX-3L-gK2" firstAttribute="leading" secondItem="jxW-8A-zuT" secondAttribute="leading" constant="8" id="UtU-rX-66V"/>
-                <constraint firstItem="jRn-wV-80l" firstAttribute="bottom" secondItem="jxW-8A-zuT" secondAttribute="bottomMargin" id="YIq-X5-Obs"/>
+                <constraint firstItem="jRn-wV-80l" firstAttribute="bottom" secondItem="jxW-8A-zuT" secondAttribute="bottomMargin" constant="-4" id="YIq-X5-Obs"/>
                 <constraint firstItem="QXb-cD-1CI" firstAttribute="top" secondItem="NvX-3L-gK2" secondAttribute="top" id="luY-hT-6PZ"/>
                 <constraint firstItem="NvX-3L-gK2" firstAttribute="bottom" secondItem="QXb-cD-1CI" secondAttribute="bottom" id="tiF-0q-rS0"/>
                 <constraint firstAttribute="bottom" secondItem="QXb-cD-1CI" secondAttribute="bottom" constant="31" id="w64-NT-EzD"/>

--- a/harbaughsim16/UpcomingViewController.m
+++ b/harbaughsim16/UpcomingViewController.m
@@ -41,8 +41,8 @@
 @interface UpcomingViewController () <UIViewControllerPreviewingDelegate>
 {
     PlayerQB *passLeader;
-    PlayerRB *rushLeader;
-    PlayerWR *recLeader;
+    Player *rushLeader;
+    Player *recLeader;
     Team *defLeader;
     PlayerK *kickLeader;
     Team *userTeam;
@@ -464,6 +464,7 @@
         [rushers addObjectsFromArray:t.teamRBs];
         [rushers addObjectsFromArray:t.teamQBs];
         [wrs addObjectsFromArray:t.teamWRs];
+        [wrs addObjectsFromArray:t.teamTEs];
         [ks addObjectsFromArray:t.teamKs];
     }
     
@@ -917,7 +918,7 @@
                 }
             } else if (indexPath.row == 1) {
                 cell.textLabel.text = @"Rushing";
-                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ RB %@", rushLeader.team.abbreviation, [rushLeader getInitialName]]];
+                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ %@ %@", rushLeader.team.abbreviation, rushLeader.position, [rushLeader getInitialName]]];
                 if (rushLeader.isHeisman) {
                     [cell.detailTextLabel setTextColor:[HBSharedUtils champColor]];
                 } else if ([cell.detailTextLabel.text containsString:userTeam.abbreviation]) {
@@ -927,7 +928,7 @@
                 }
             } else if (indexPath.row == 2) {
                 cell.textLabel.text = @"Receiving";
-                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ WR %@", recLeader.team.abbreviation, [recLeader getInitialName]]];
+                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ %@ %@", recLeader.team.abbreviation, recLeader.position, [recLeader getInitialName]]];
                 if (recLeader.isHeisman) {
                     [cell.detailTextLabel setTextColor:[HBSharedUtils champColor]];
                 } else if ([cell.detailTextLabel.text containsString:userTeam.abbreviation]) {
@@ -1083,7 +1084,7 @@
                 }
             } else if (indexPath.row == 1) {
                 cell.textLabel.text = @"Rushing";
-                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ RB %@", rushLeader.team.abbreviation, [rushLeader getInitialName]]];
+                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ %@ %@", rushLeader.team.abbreviation,rushLeader.position, [rushLeader getInitialName]]];
                 if (rushLeader.isHeisman) {
                     [cell.detailTextLabel setTextColor:[HBSharedUtils champColor]];
                 } else if ([cell.detailTextLabel.text containsString:userTeam.abbreviation]) {
@@ -1093,7 +1094,7 @@
                 }
             } else if (indexPath.row == 2) {
                 cell.textLabel.text = @"Receiving";
-                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ WR %@", recLeader.team.abbreviation, [recLeader getInitialName]]];
+                [cell.detailTextLabel setText:[NSString stringWithFormat:@"%@ %@ %@", recLeader.team.abbreviation,recLeader.position, [recLeader getInitialName]]];
                 if (recLeader.isHeisman) {
                     [cell.detailTextLabel setTextColor:[HBSharedUtils champColor]];
                 } else if ([cell.detailTextLabel.text containsString:userTeam.abbreviation]) {

--- a/harbaughsim16/UpcomingViewController.m
+++ b/harbaughsim16/UpcomingViewController.m
@@ -457,11 +457,12 @@
     
     NSMutableArray *qbs = [NSMutableArray array];
     NSMutableArray *ks = [NSMutableArray array];
-    NSMutableArray *rbs = [NSMutableArray array];
+    NSMutableArray *rushers = [NSMutableArray array];
     NSMutableArray *wrs = [NSMutableArray array];
     for (Team *t in simLeague.teamList) {
         [qbs addObjectsFromArray:t.teamQBs];
-        [rbs addObjectsFromArray:t.teamRBs];
+        [rushers addObjectsFromArray:t.teamRBs];
+        [rushers addObjectsFromArray:t.teamQBs];
         [wrs addObjectsFromArray:t.teamWRs];
         [ks addObjectsFromArray:t.teamKs];
     }
@@ -471,10 +472,32 @@
         PlayerQB *b = (PlayerQB*)obj2;
         return (a.statsPassYards > b.statsPassYards) ? -1 : ((a.statsPassYards == b.statsPassYards) ? [a.name compare:b.name] : 1);
     }];
-    [rbs sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-        PlayerRB *a = (PlayerRB*)obj1;
-        PlayerRB *b = (PlayerRB*)obj2;
-        return (a.statsRushYards > b.statsRushYards) ? -1 : ((a.statsRushYards == b.statsRushYards) ? [a.name compare:b.name] : 1);
+    [rushers sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        Player *a = (Player*)obj1;
+        Player *b = (Player*)obj2;
+        if (([a isKindOfClass:[PlayerQB class]] || [a isKindOfClass:[PlayerRB class]]) && ([b isKindOfClass:[PlayerQB class]] || [b isKindOfClass:[PlayerRB class]])) {
+            int aYards;
+            int bYards;
+            if ([a isKindOfClass:[PlayerQB class]]) {
+                aYards = ((PlayerQB*)a).statsRushYards;
+            } else if ([a isKindOfClass:[PlayerRB class]]) {
+                aYards = ((PlayerRB*)a).statsRushYards;
+            } else {
+                aYards = 0;
+            }
+            
+            if ([b isKindOfClass:[PlayerQB class]]) {
+                bYards = ((PlayerQB*)b).statsRushYards;
+            } else if ([b isKindOfClass:[PlayerRB class]]) {
+                bYards = ((PlayerRB*)b).statsRushYards;
+            } else {
+                bYards = 0;
+            }
+            
+            return (aYards > bYards) ? -1 : ((aYards == bYards) ? [a.name compare:b.name] : 1);
+        } else {
+            return [a.name compare:b.name];
+        }
     }];
     [wrs sortUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
         PlayerWR *a = (PlayerWR*)obj1;
@@ -494,7 +517,7 @@
     
     
     passLeader = [qbs firstObject];
-    rushLeader = [rbs firstObject];
+    rushLeader = [rushers firstObject];
     recLeader = [wrs firstObject];
     kickLeader = [ks firstObject];
     defLeader = [teams firstObject];


### PR DESCRIPTION
* Fixed an issue where prestige labels were cut off vertically.
* Fixed POTY from being awarded multiple times.
* Extended notifications display time.
* Fixed scheduling so that teams play 6 away and 6 home games.
* Added a minimum level of recruiting effort that is independent of prestige. 
* Fixed an issue with team renaming.
* Added QBs to Rushing Leaders panel.
* Fixed an issue where TEs wouldn't get drafted.
* Adjusted dual-threat vs pro-style labeling for QBs in recruiting.
* Fixed an issue where team name matching was done incorrectly in team stat rankings.
* Added TEs to Receiving Leaders panel.

**Status** (02/25/2018): Release Candidate